### PR TITLE
GCP にデプロイできるようにする1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# use this Dockerfile to install additional tools you might need, e.g.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN sudo apt-get update && sudo apt-get -y install google-cloud-cli

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,3 +6,4 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN sudo apt-get update && sudo apt-get -y install google-cloud-cli
+RUN gcloud config set project charactermanager-350911 && gcloud config set compute/region asia-northeast1 && gcloud auth configure-docker asia-northeast1-docker.pkg.dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// The Dev Container format allows you to configure your environment. At the heart of it
+// is a Docker image or Dockerfile which controls the tools available in your environment.
+//
+// See https://aka.ms/devcontainer.json for more information.
+{
+	"name": "Ona",
+	// Use "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	// instead of the build to use a pre-built image.
+	"build": {
+        "context": ".",
+        "dockerfile": "Dockerfile"
+    },
+	// Features add additional features to your environment. See https://containers.dev/features
+	// Beware: features are not supported on all platforms and may have unintended side-effects.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": true,
+			"installDockerBuildx": true,
+			"version": "latest",
+			"dockerDashComposeVersion": "v2"
+		}
+	}
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,155 @@
+# GitHub Actions Workflows
+
+## Docker Build and Push to GCP
+
+Workflow: `docker-build-push.yml`
+
+### Trigger
+
+**Automatic:**
+- Push tags with the following patterns:
+  - `frontend-*` - Builds and pushes frontend Docker image
+  - `backend-*` - Builds and pushes backend Docker image
+
+**Manual:**
+- Workflow dispatch with tag name input
+- Can be triggered from GitHub Actions UI or API
+
+### Required Secrets
+
+Configure these in GitHub repository settings (Settings → Secrets and variables → Actions):
+
+#### Secrets
+
+| Name | Description | Example |
+|------|-------------|---------|
+| `GCP_SA_KEY` | GCP Service Account JSON key | `{"type": "service_account", ...}` |
+| `GCP_PROJECT_ID` | GCP Project ID | `my-project-12345` |
+
+#### Variables (Optional)
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `GCP_REGION` | GCP region for Artifact Registry | `asia-northeast1` |
+| `ARTIFACT_REGISTRY_REPO` | Artifact Registry repository name | `character-manager` |
+
+### GCP Setup
+
+#### 1. Create Service Account
+
+```bash
+# Set project
+gcloud config set project YOUR_PROJECT_ID
+
+# Create service account
+gcloud iam service-accounts create github-actions \
+  --display-name="GitHub Actions"
+
+# Grant permissions
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="serviceAccount:github-actions@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/artifactregistry.writer"
+
+# Create and download key
+gcloud iam service-accounts keys create github-actions-key.json \
+  --iam-account=github-actions@YOUR_PROJECT_ID.iam.gserviceaccount.com
+```
+
+#### 2. Create Artifact Registry Repository
+
+```bash
+gcloud artifacts repositories create character-manager \
+  --repository-format=docker \
+  --location=asia-northeast1 \
+  --description="Character Manager Docker images"
+```
+
+#### 3. Add Secret to GitHub
+
+1. Go to repository Settings → Secrets and variables → Actions
+2. Click "New repository secret"
+3. Name: `GCP_SA_KEY`
+4. Value: Contents of `github-actions-key.json`
+5. Add another secret:
+   - Name: `GCP_PROJECT_ID`
+   - Value: Your GCP project ID
+
+### Usage
+
+#### Automatic: Create and push tags
+
+```bash
+# Frontend release
+git tag frontend-v1.0.0
+git push origin frontend-v1.0.0
+
+# Backend release
+git tag backend-v1.0.0
+git push origin backend-v1.0.0
+```
+
+#### Manual: Trigger from GitHub UI
+
+1. Go to repository Actions tab
+2. Select "Build and Push Docker Images to GCP" workflow
+3. Click "Run workflow" button
+4. Enter tag name (e.g., `frontend-v1.0.0` or `backend-v1.0.0`)
+5. Click "Run workflow"
+
+#### Manual: Trigger from GitHub CLI
+
+```bash
+# Frontend release
+gh workflow run docker-build-push.yml -f tag_name=frontend-v1.0.0
+
+# Backend release
+gh workflow run docker-build-push.yml -f tag_name=backend-v1.0.0
+```
+
+#### Manual: Trigger from API
+
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer YOUR_GITHUB_TOKEN" \
+  https://api.github.com/repos/OWNER/REPO/actions/workflows/docker-build-push.yml/dispatches \
+  -d '{"ref":"main","inputs":{"tag_name":"frontend-v1.0.0"}}'
+```
+
+#### Resulting images
+
+```
+asia-northeast1-docker.pkg.dev/YOUR_PROJECT_ID/character-manager/frontend:v1.0.0
+asia-northeast1-docker.pkg.dev/YOUR_PROJECT_ID/character-manager/frontend:latest
+
+asia-northeast1-docker.pkg.dev/YOUR_PROJECT_ID/character-manager/backend:v1.0.0
+asia-northeast1-docker.pkg.dev/YOUR_PROJECT_ID/character-manager/backend:latest
+```
+
+### Tag Format
+
+- Tag must start with `frontend-` or `backend-`
+- Version is extracted from everything after the prefix
+- Examples:
+  - `frontend-v1.0.0` → version: `v1.0.0`
+  - `backend-2024.12.08` → version: `2024.12.08`
+  - `frontend-1.2.3-rc1` → version: `1.2.3-rc1`
+
+### Workflow Steps
+
+1. Checkout code
+2. Determine tag name (from push event or manual input)
+3. Determine which service to build based on tag prefix
+4. Authenticate to GCP using service account key
+5. Configure Docker to use Artifact Registry
+6. Extract version from tag name
+7. Build Docker image with version and latest tags
+8. Push both tags to Artifact Registry
+9. Output image details in workflow summary
+
+### Notes
+
+- Manual execution uses the current branch code (typically `main`)
+- Tag name validation ensures it starts with `frontend-` or `backend-`
+- Both automatic and manual triggers produce identical results
+- Manual execution does not create a git tag

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,106 @@
+name: Build and Push Docker Images to GCP
+
+on:
+  push:
+    tags:
+      - 'frontend-*'
+      - 'backend-*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name (e.g., frontend-v1.0.0 or backend-v1.0.0)'
+        required: true
+        type: string
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast1' }}
+  ARTIFACT_REGISTRY_REPO: ${{ vars.ARTIFACT_REGISTRY_REPO || 'character-manager' }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.ref }}
+
+      - name: Determine tag name
+        id: determine-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG_NAME="${{ inputs.tag_name }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
+          fi
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Determine service to build
+        id: determine-service
+        run: |
+          TAG_NAME="${{ steps.determine-tag.outputs.tag_name }}"
+          if [[ "$TAG_NAME" == frontend-* ]]; then
+            echo "service=frontend" >> $GITHUB_OUTPUT
+            echo "context=./frontend" >> $GITHUB_OUTPUT
+            echo "dockerfile=./frontend/Dockerfile" >> $GITHUB_OUTPUT
+          elif [[ "$TAG_NAME" == backend-* ]]; then
+            echo "service=backend" >> $GITHUB_OUTPUT
+            echo "context=./backend" >> $GITHUB_OUTPUT
+            echo "dockerfile=./backend/Dockerfile" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid tag name: $TAG_NAME"
+            echo "Tag must start with 'frontend-' or 'backend-'"
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: |
+          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
+
+      - name: Extract version from tag
+        id: extract-version
+        run: |
+          TAG_NAME="${{ steps.determine-tag.outputs.tag_name }}"
+          VERSION="${TAG_NAME#*-}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          SERVICE="${{ steps.determine-service.outputs.service }}"
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          IMAGE_NAME="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPO }}/$SERVICE"
+          
+          docker build \
+            -t "$IMAGE_NAME:$VERSION" \
+            -t "$IMAGE_NAME:latest" \
+            -f ${{ steps.determine-service.outputs.dockerfile }} \
+            ${{ steps.determine-service.outputs.context }}
+          
+          docker push "$IMAGE_NAME:$VERSION"
+          docker push "$IMAGE_NAME:latest"
+
+      - name: Output image details
+        run: |
+          SERVICE="${{ steps.determine-service.outputs.service }}"
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          IMAGE_NAME="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPO }}/$SERVICE"
+          
+          echo "### Docker Image Published :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Service:** $SERVICE" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`$IMAGE_NAME:$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Latest:** \`$IMAGE_NAME:latest\`" >> $GITHUB_STEP_SUMMARY

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,39 @@
 import os
+import logging
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routers import auth, characters, share, images, dice
+from alembic.config import Config
+from alembic import command
 
-app = FastAPI(title="Character Manager API", version="1.0.0")
+logger = logging.getLogger(__name__)
+
+
+def run_migrations():
+    """Run database migrations on startup."""
+    try:
+        logger.info("Running database migrations...")
+        alembic_cfg = Config("alembic.ini")
+        command.upgrade(alembic_cfg, "head")
+        logger.info("Database migrations completed successfully")
+    except Exception as e:
+        logger.error(f"Failed to run migrations: {e}")
+        raise
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan events."""
+    run_migrations()
+    yield
+
+
+app = FastAPI(
+    title="Character Manager API",
+    version="1.0.0",
+    lifespan=lifespan
+)
 
 # CORS設定
 CORS_ORIGINS = os.getenv(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routers import auth, characters, share, images, dice
@@ -5,9 +6,15 @@ from app.routers import auth, characters, share, images, dice
 app = FastAPI(title="Character Manager API", version="1.0.0")
 
 # CORS設定
+CORS_ORIGINS = os.getenv(
+    "CORS_ORIGINS",
+    "http://localhost:5173,http://localhost:3000"
+)
+allow_origins = [origin.strip() for origin in CORS_ORIGINS.split(",")]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],  # フロントエンドのオリジン
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    allowedHosts: [
+      '.asia-northeast1.run.app'
+    ],
+  }
 })


### PR DESCRIPTION
- デプロイまで完全にCIでやろうとすると変更大きすぎるのでいったん自動 push まで (なのでタイトルは1)
  - tag 作成or手動で実行する workflow を作成
- その他デプロイに必要なコード変更を入れた(backend)
- ついでに devcontainer の設定ファイルと Dockerfile も
  - 同じようなことやれば gcloud コマンドがローカルでも使える
  - ローカルだと gcloud auth login で Google アカウントの認証挟む必要はある